### PR TITLE
Photon 2.0 Bug fix to properly identify VMware Photon OS.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,22 +3,22 @@ This is a [Vagrant](http://www.vagrantup.com/) [plugin](http://docs.vagrantup.co
 
 ## Installation
 
-```
+```shell
 $ vagrant plugin install vagrant-guests-photon
 ```
 
 ## Development
 To build and install the plugin directly from this repo:
 
-```
+```shell
 $ bundle install
-$ bundle rake build
+$ bundle exec rake build
 $ vagrant plugin install pkg/vagrant-guests-photon-1.0.2.gem
 ```
 
 You can run RSpec with:
 
-```
+```shell
 $ bundle install
 $ bundle exec rake
 ```

--- a/lib/vagrant-guests-photon/guest.rb
+++ b/lib/vagrant-guests-photon/guest.rb
@@ -7,7 +7,7 @@ module VagrantPlugins
   module GuestPhoton
     class Guest < Vagrant.plugin('2', :guest)
       def detect?(machine)
-        machine.communicate.test("cat /etc/photon-release | grep 'VMware Photon Linux'")
+        machine.communicate.test("grep 'VMware Photon' /etc/photon-release")
       end
     end
   end

--- a/lib/vagrant-guests-photon/version.rb
+++ b/lib/vagrant-guests-photon/version.rb
@@ -4,6 +4,6 @@
 module VagrantPlugins
   # Set version for vagrant-guests-photon gem.
   module GuestPhoton
-    VERSION = '1.0.4'
+    VERSION = '1.0.5'
   end
 end

--- a/spec/guest_spec.rb
+++ b/spec/guest_spec.rb
@@ -8,7 +8,7 @@ describe VagrantPlugins::GuestPhoton::Guest do
   include_context 'machine'
 
   it 'should be detected with Photon' do
-    expect(communicate).to receive(:test).with("cat /etc/photon-release | grep 'VMware Photon Linux'")
+    expect(communicate).to receive(:test).with("grep 'VMware Photon' /etc/photon-release")
     guest.detect?(machine)
   end
 end

--- a/vagrant-guests-photon.gemspec
+++ b/vagrant-guests-photon.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.description = 'Enables Vagrant to manage VMware Photon machines.'
 
   s.add_development_dependency 'bundler'
-  s.add_development_dependency 'rake'
+  s.add_development_dependency 'rake', '< 11.0'
   s.add_development_dependency 'rspec-core', '~> 2.14'
   s.add_development_dependency 'rspec-expectations', '~> 2.14'
   s.add_development_dependency 'rspec-mocks', '~> 2.14'


### PR DESCRIPTION
In the Photon 2.0 release, /etc/photon-release doesn't have `VMware Photon Linux` anymore. It contains:
```shell
root@photon-2.0-ankurh [ ~ ]# cat /etc/photon-release
VMware Photon OS 2.0
```
Fixing the code to grep for only VMware Photon instead of VMware Photon Linux. Other tiny changes include:

- Fix the README file with the proper `bundle` command
- Fix the gemspec file to have a rspec version < 11.0 because of https://stackoverflow.com/questions/35893584/nomethoderror-undefined-method-last-comment-after-upgrading-to-rake-11

Testing output:
```shell
 huralikoppia@huralikoppia-m03 ~/code/vagrant-guests-photon $ rspec                                                                                                                      ✔  5058  15:27:40
[Coveralls] Set up the SimpleCov formatter.
[Coveralls] Using SimpleCov's default settings.
..........

Finished in 0.01164 seconds
10 examples, 0 failures
[Coveralls] Outside the CI environment, not sending data.
```